### PR TITLE
fix broken things about company data

### DIFF
--- a/companies/Makefile
+++ b/companies/Makefile
@@ -5,7 +5,7 @@
 #  Companies House "free" data, see:
 #  http://download.companieshouse.gov.uk/en_output.html
 #
-DATE=2015-02-01
+DATE=2015-08-01
 URL_PREFIX=http://download.companieshouse.gov.uk/BasicCompanyData-$(DATE)-part
 URL_SUFFIX=_5.zip
 
@@ -19,14 +19,14 @@ COMPANIES_DATA=\
 #
 #  Register information from the register.register
 #
-REGISTER_URL=https://raw.githubusercontent.com/openregister/register.register/master/data/Register
+REGISTER_URL=https://raw.githubusercontent.com/openregister/registers/master/data/Register
 REGISTERS=\
-	cache/Company.yaml\
-	cache/Address.yaml
+	cache/company.yaml\
+	cache/address.yaml
 
-COUNTRY_URL=https://raw.githubusercontent.com/openregister/country.register/master/data/Country/countries.yaml
+COUNTRY_URL=https://raw.githubusercontent.com/openregister/locations/master/country/data/Country/countries.tsv
 COUNTRIES=\
-	cache/countries.yaml
+	cache/countries.tsv
 
 .PHONY: all flake8 prune out
 
@@ -69,13 +69,13 @@ cache/part5.zip:;	mkdir -p cache && curl -s "$(URL_PREFIX)5$(URL_SUFFIX)" > $@
 #
 #  registers
 #
-cache/Company.yaml:;	mkdir -p cache && curl -L -s "$(REGISTER_URL)/Company.yaml" > $@
-cache/Address.yaml:;	mkdir -p cache && curl -L -s "$(REGISTER_URL)/Address.yaml" > $@
+cache/company.yaml:;	mkdir -p cache && curl -L -s "$(REGISTER_URL)/company.yaml" > $@
+cache/address.yaml:;	mkdir -p cache && curl -L -s "$(REGISTER_URL)/address.yaml" > $@
 
 #
 #  country codes
 #
-cache/countries.yaml:;	mkdir -p cache && curl -L -s "$(COUNTRY_URL)" > $@
+cache/countries.tsv:;	mkdir -p cache && curl -L -s "$(COUNTRY_URL)" > $@
 
 #
 #  clean

--- a/companies/requirements.txt
+++ b/companies/requirements.txt
@@ -4,4 +4,4 @@ mccabe==0.3
 pep8==1.5.7
 pyflakes==0.8.1
 pymongo==2.7.2
--e git+https://github.com/openregister/entry@c02f86d1698e32c795332e74c5b2ccbec5f3558e#egg=thingstance-origin/master
+-e git+https://github.com/openregister/entry@c02f86d1698e32c795332e74c5b2ccbec5f3558e#egg=thingstance


### PR DESCRIPTION
1. there's been a new release of basic company data, so (of course) the
   old URLs now 404 :(
2. the requirements.txt format didn't work at all for me, but manually
   fiddling with it produced something that seemed to work
3. the register register data and country register data has moved, so
   the URLs needed updating

unfortunately I still get errors even after this commit:

```
$ make
flake8 bin
mkdir -p cache && curl -s "http://download.companieshouse.gov.uk/BasicCompanyData-2015-08-01-part1_5.zip" > cache/part1.zip
funzip cache/part1.zip | bin/companies.py part1
Traceback (most recent call last):
  File "bin/companies.py", line 67, in <module>
    addresses.write(address)
  File "/Users/philandstuff/openregister/data/organisations/companies/src/thingstance/thingstance/representations/csv.py", line 60, in write
    self.writer.writerow(thing.primitive)
  File "/opt/boxen/homebrew/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/csv.py", line 153, in writerow
    return self.writer.writerow(self._dict_to_list(rowdict))
  File "/opt/boxen/homebrew/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/csv.py", line 149, in _dict_to_list
    + ", ".join([repr(x) for x in wrong_fields]))
ValueError: dict contains fields not in fieldnames: 'addressCountry', 'addressRegion', 'addressLocality', 'postalCode', 'postOfficeBoxNumber', 'streetAddress'
make: *** [data/Company/part1.tsv] Error 1
```

I don't know what this is trying to tell me.
